### PR TITLE
feat: Material Symbols Iconsの追加とサイドバーのMVP範囲への調整

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -6,6 +6,6 @@
   }
   
   .sidebar-link {
-    @apply text-2xl font-bold flex items-center px-3 py-2 mb-1 text-gray-700 rounded-md hover:bg-gray-100;
+    @apply text-2xl font-bold flex items-center gap-3 px-3 py-2 mb-1 text-gray-700 rounded-md hover:bg-gray-100;
   }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <link rel="icon" href="/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -1,19 +1,12 @@
 <div class="fixed top-16 bottom-0 left-0 w-64 bg-white border-r border-gray-200 overflow-y-auto">
   <nav class="py-4 px-3">
     <a href="#" class="sidebar-link">
+      <span class="material-symbols-outlined">list_alt</span>
       施工一覧
     </a>
     <a href="#" class="sidebar-link">
+      <span class="material-symbols-outlined">add_circle</span>
       施工登録
-    </a>
-    <a href="#" class="sidebar-link">
-      材料管理
-    </a>
-    <a href="#" class="sidebar-link">
-      メーカー管理
-    </a>
-    <a href="#" class="sidebar-link">
-      ユーザー管理
     </a>
   </nav>
 </div>


### PR DESCRIPTION
## 概要
対応Issue：#6
Material Symbols Iconsの追加

## 目的
- アイコンを使い視認性向上

## 対応内容
- Material Symbols Icons CDNをレイアウトに追加（開発時は柔軟な健康に対応するためカスタムオプション全部参照)- サイドバーメニューにアイコンを追加（施工一覧、施工登録）
- サイドバーメニューをMVP範囲に絞り込み（材料管理、メーカー管理、ユーザー管理を削除）
- サイドバーリンクのアイコンと文字の間隔調整（gap-3）

## 動作確認方法
1. `http://0.0.0.0:3000`にアクセス
2. サイドバーにアイコン表示
3. アイコンと文字に隙間がある

## 影響範囲
- 画面全体(サイドバー)

## 備考
- MVP要件以外のメニュー削除

Closes #6